### PR TITLE
feat(complete-withdrawals): add the completeWithdrawals field

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -453,6 +453,7 @@ export interface ApiConfig {
     depositConfirmations: number;
     zksyncVersion: 'contractV4';
     // TODO: server_version (ZKS-627)
+    completeWithdrawals: boolean
 }
 
 export interface FeeRest {


### PR DESCRIPTION
## What 

- add the 'completeWithdrawals' field in the config type

## Why

- because the server returns that field in the `/v0.2/config` endpoint
- that endpoint could be used to configure the dapp accordingly

> [!IMPORTANT]
This field will be available only after merging the [server PR](https://github.com/rsksmart/rif-rollup/pull/104)

## References

- https://github.com/rsksmart/rif-rollup/pull/104